### PR TITLE
Added 'essential' property to the records in the template to indicate…

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -3,8 +3,8 @@
 :toclevels: 4
 :source-highlighter: prettify
 :sectnums:
-:revnumber: 44
-:revdate: 23-03-2018
+:revnumber: 45
+:revdate: 19-04-2018
 :revremark: DRAFT 
 :apply-image-size:
 
@@ -1388,6 +1388,19 @@ SRV: name, target, protocol, service, priority, weight, port, TTL
 |This OPTIONAL parameter identifies the group
 the record belongs to when applying changes.
 
+[[essential-record]]
+|*Essential*
+|enum
+|essential
+|(optional)
+This parameter indicates, whether record is obligatory or optional during template application and whether it can be removed without the whole template after application
+
+Always (default) - record MUST be applied and kept with the template
+
+OnApply - record MUST be applied and but can be later removed
+
+No - record is optional to apply and but can be later removed
+
 |*Host*
 |String
 |host a|
@@ -1514,6 +1527,12 @@ which should be replaced
 * Replace any record for CNAME
 * Remove any CNAME record existing at the same or parent level to any
 records added by the template
+
+=== Non-essential records
+
+Typically template specifies a list of DNS records which all are essential to the full functionality of the service. There might appear cases, where some records are of optional or nice-to-have nature, which template provider would like to set, but if there is a conflict with existing record or template it is also correct to apply the template without them not affecting the functionality of the service itself. It is especially useful for the sync flow, where Service Provider may want to avoid splitting into several templates and multiple round-trips towards DNS-Providre to achieve the same result.
+Similar situation may appear if a record is required at the time of template application, but afterwards it's OK to remove this record, either by customer action or conflict resolution - without need to remove the whole template as such. 
+These particularities may be controlled by <<essential-record, essential>> property of a record in the template.
 
 === Template Scope
 


### PR DESCRIPTION
… optional records

Hi, working on one of the integrations we came to a situation where the service provider would like to include "_acme-challenge" record as part of the template and have it applied together with other records in one "sync" step.
It makes sense, but when any other provider or end-user himself would like to make ACME process on his own, it would remove the whole template from DNS - rather unwanted side-effect.

Therefore I propose to add a property to the record allowing to mark it as optional and not breaking the template if removed.
