### PR TITLE
Marking syncPubKeyDomain as optional

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -1312,7 +1312,8 @@ is false.
 |*Synchronous Public Key Domain*
 |String
 |syncPubKeyDomain
-|When present,
+|(optional)
+When present,
 indicates that calls to apply a template synchronously will be digitally
 signed. This element contains the domain name for querying the TXT
 record from DNS that contains the public key information.


### PR DESCRIPTION
syncPubKeyDomain was optional from the description, but explicit marking was missing.