### PR TITLE
Update SPFM alternatives section

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -1805,8 +1805,7 @@ See <<example-spf-merge>>.
 
 ==== Alternatives
 
-Some DNS Providers may decide not to support SPFM record. Following alternative solution shall allow general interoperability of the templates for those providers:
-- onboard the templates with SPFM record in variable-compatible form using regular TXT record with a content _“v=spf1 %spfRules% -all”_, using property _essential=OnApply_ set to avoid removal of the whole template by a conflict
+Some DNS Providers may decide not to support SPFM record. Following alternative solution shall allow general interoperability of the templates for those providers: onboard the templates with SPFM record in variable-compatible form using regular TXT record with a content _“v=spf1 %spfRules% -all”_, using property _essential=OnApply_ set to avoid removal of the whole template by a conflict
 
 === Repository and Integrity
 

--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -1805,9 +1805,7 @@ See <<example-spf-merge>>.
 
 ==== Alternatives
 
-Some DNS Providers may decide not to support SPFM record. Following alternative solutions shall allow general interoperability of the templates for those providers:
-
-- onboard the templates with SPFM and follow the guidance at <<SPF record merging, SPF record merging>>, or
+Some DNS Providers may decide not to support SPFM record. Following alternative solution shall allow general interoperability of the templates for those providers:
 - onboard the templates with SPFM record in variable-compatible form using regular TXT record with a content _“v=spf1 %spfRules% -all”_, using property _essential=OnApply_ set to avoid removal of the whole template by a conflict
 
 === Repository and Integrity

--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -680,7 +680,7 @@ also indicates that the signing algorithm is an RSA Signature with
 SHA-256 using an x509 certificate. The value for "a" if omitted will be
 assumed to be RS256, and for "t" will be assumed to be x509.
 
-Note: The only algorithm currently supported is SHA-256 with x509 certificates. The value is placed here for future compatability.
+Note: The only algorithm currently supported is SHA-256 with x509 certificates. The value is placed here for future compatibility.
 
 The above data was generated for a query string:
 
@@ -776,7 +776,7 @@ implementation. This includes valid URLs and Domains for redirects upon
 success or errors.
 
 Note: The validity of redirects are very important in any oAuth implementation. 
-Most oAuth vunerabilities are a combination of a leaked redirect and/or a compromised secret.
+Most oAuth vulnerabilities are a combination of a leaked redirect and/or a compromised secret.
 
 In return, the DNS provider will give the Service Provider a client id
 and secret which will be used when requesting tokens. It is also
@@ -844,7 +844,7 @@ an error code as query parameter "error". These errors are also from the
 oAuth 2.0 RFC 6749 (4.1.2.1. Error Response - "error" parameter). Valid
 values include: invalid_request, unauthorized_client, access_denied,
 unsupported_response_type, invalid_scope, server_error, and
-temorarilly_unavailable. An optional error_description suitable for
+temporarilly_unavailable. An optional error_description suitable for
 developers can also be returned at the discretion of the DNS Provider.
 The same considerations as in the synchronous flow apply here.
 
@@ -924,7 +924,7 @@ This token exchange is typically done via a server to server API call from the
 Service Provider to the DNS Provider using a POST. When called in this manner a secret is provided
 along with the Authorization Code.
 
-oAuth does allow for retreiving the access token without a secret. This is typically done when the
+oAuth does allow for retrieving the access token without a secret. This is typically done when the
 oAuth client is a client application.
 When onboarding with the DNS Provider this would need to be enabled.
 
@@ -1093,7 +1093,7 @@ This can also be a comma separated list of groupIds.
 
 |*Force*
 |force
-|(optional) Thisparameter specifies that the template
+|(optional) This parameter specifies that the template
 should be applied independently of any conflicts that may exist on the
 domain. This can be a value of 0 or 1.
 |=======================================================================
@@ -1344,7 +1344,7 @@ to with the response for the configuration.
 |warnPhishing
 |(optional)
 When present, this tells the DNS Provider that the template may contain 
-variables susceptiable to phishing attacks and the provider is unable to digitally sign the
+variables susceptible to phishing attacks and the provider is unable to digitally sign the
 requests. The default value for this is false.
 
 |*Host Required*
@@ -1575,7 +1575,7 @@ records added by the template
 [[non-essential-record]]
 === Non-essential records
 
-Typically a template specifices a list of DNS records which are required for the service. There may be cases where some records are only required for a very short period of time, and removing or altering the record later (either by the end user or through application of another template) should not trigger conflict detection.
+Typically a template specifies a list of DNS records which are required for the service. There may be cases where some records are only required for a very short period of time, and removing or altering the record later (either by the end user or through application of another template) should not trigger conflict detection.
 
 This can be controlled by the <<essential-record, essential>> property of a record in the template.
 
@@ -1772,7 +1772,7 @@ We combined the two rules, and in this case picked the least restrictive all mod
 
 The challenge with SPF records and Domain Connect is that an individual service might recommend an SPF record. If only one service were active, this would be accurate, but with several services together only DNS Provider is able to determine the valid shape of SPF TXT record.
 
-One solution to this problem is to merge all related records. At the highest level, this means taking everything between the “v=spf1” and the “-all” from each of the records and merging them together, terminating with hard-coded modifier on _all_ at the end. For the purpose of SPF record to fulfill it's purpose of protection agains malicous E-mail delivery Domain Connect defines a fixed modifier _"-"_ advising rejection of the messages from other sources not specified in SPF. End user can always modify it after merge operation is completed.
+One solution to this problem is to merge all related records. At the highest level, this means taking everything between the “v=spf1” and the “-all” from each of the records and merging them together, terminating with hard-coded modifier on _all_ at the end. For the purpose of SPF record to fulfill it's purpose of protection against malicious E-mail delivery Domain Connect defines a fixed modifier _"-"_ advising rejection of the messages from other sources not specified in SPF. End user can always modify it after merge operation is completed.
 
 ----
 @ TXT v=spf1 include:spf.mailer1.com include:_spf.newsletter.net -all
@@ -1807,7 +1807,7 @@ See <<example-spf-merge>>.
 
 Some DNS Providers may decide not to support SPFM record. Following alternative solutions shall allow general interoperability of the templates for those providers:
 
-- ignore SPFM - will secure that services would not run into conflict with each other, with a disadvantage of lacking SPF, or
+- onboard the templates with SPFM and follow the guidance at <<SPF record merging, SPF record merging>>, or
 - onboard the templates with SPFM record in variable-compatible form using regular TXT record with a content _“v=spf1 %spfRules% -all”_, using property _essential=OnApply_ set to avoid removal of the whole template by a conflict
 
 === Repository and Integrity


### PR DESCRIPTION
Update SPFM alternatives section to clearly specify that ignoring SPFM record is not really an option as it would lead to partially applied templates. Customers have the option to implement the recommendation from section 6.6.3 or take the variable from the SPFM and compose their own SPF record in the form of “v=spf1 %spfRules% -all”

I also fixed some typos 