### PR TITLE
Making language for ProviderID more consistent between SP and DP

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -324,8 +324,8 @@ otherwise specified.
 |*Provider Id*
 |providerId
 |String
-|Unique identifier for the DNS Provider. Typically a  domain name (e.g. virtucom.com) of the
-DNS Provider.
+|Unique identifier for the DNS Provider. To ensure non-coordinated uniqueness,
+|this should be the domain name of the DNS Provider (e.g. virtucom.com).
 
 |*Provider Name* 
 |providerName


### PR DESCRIPTION
I prepared this in collaboration with @kgrand84. It's confusing to see that the ProviderID is "typically" for the DNS Provider case, and "should" for the Service Provider case. We're assuming this distinction was not intentionally, and submit this PR to clarify that.