### PR TITLE
Fix formatting on DNS Provider Discovery table

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -332,7 +332,7 @@ otherwise specified.
 |providerId
 |String
 |Unique identifier for the DNS Provider. To ensure non-coordinated uniqueness,
-|this should be the domain name of the DNS Provider (e.g. virtucom.com).
+this should be the domain name of the DNS Provider (e.g. virtucom.com).
 
 |*Provider Name* 
 |providerName


### PR DESCRIPTION
Just noticed that this table got misconfigured up at some point. Thanks for the doc, very helpful!