### PR TITLE
Make nearly everything case sensitive

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -149,7 +149,10 @@ The template is defined by the Service Provider and manually onboarded with the 
 Provider.
 Future versions of this specification may allow for an independent repository
 of templates. For now the templates are all published at
-https://github.com/Domain-Connect/templates
+https://github.com/Domain-Connect/templates. The filenames in this repository
+must be all lower case, including the providerId and serviceId. As a result,
+while the providerId and serviceId can be mixed case, all providerIds and
+serviceIds in this repository must be unique when lower case.
 
 By basing the protocol on templates instead of DNS Records, several
 advantages are achieved. The DNS Provider has very explicit knowledge

--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -175,9 +175,10 @@ a domain name.
 
 === Case Sensitivity
 
-All values are case sensitive, with the following exceptions:
+All JSON object names, JSON object values, variable names, query parameters and query parameter values are case sensitive, with the following exceptions:
 
-* Any host names or domain names
+* While providerID and serviceID are case sensitive, when retrieving the template from the DomainConnect Template Repository, the providerId and serviceId are all lower-case
+* Domain and host values for application of templates, as domains and sub-domains are not case sensitive
 
 == Protocol Overview and End User Flows
 

--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -180,7 +180,9 @@ a domain name.
 
 All JSON object names, JSON object values, variable names, query parameters and query parameter values are case sensitive, with the following exceptions:
 
-* While providerID and serviceID are case sensitive, when retrieving the template from the DomainConnect Template Repository, the providerId and serviceId are all lower-case
+* When retrieving the template from the DomainConnect Template Repository, the
+providerId and serviceId are all lower case. Regardless of how the template is
+retrieved, the providerId and serviceId are case sensitive.
 * Domain and host values for application of templates, as domains and sub-domains are not case sensitive
 
 == Protocol Overview and End User Flows

--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -177,11 +177,7 @@ a domain name.
 
 All values are case sensitive, with the following exceptions:
 
-* The following data passed in query strings:
-** The value of the serviceId, providerId, domain and host
-** All variable names
-* Variable names in templates are case insensitive
-* All variable names/keys in JSON documents are case insensitive
+* Any host names or domain names
 
 == Protocol Overview and End User Flows
 


### PR DESCRIPTION
After talking about this with Arnold on Slack, it sounds like we need to support the following circumstances:

* Some implementations will be retrieving/looking up templates in a case sensitive manner
* Other implementations will be retrieving/looking up templates in a case insensitive manner
* We want to store templates in the Domain Connect Template Repository in all lower case
* We want to clarify to the reader that serviceIds and providerIds need to be unique when they are all lower case

I understand that we want to require case sensitivity for providerId and serviceId, but I can see some implementations rely on the initial lookup of the template, without further validation. For example, we can see this today with DomainConnectApplyZone project (see https://github.com/Domain-Connect/DomainConnectApplyZone/blob/master/domainconnectzone/DomainConnect.py#L677). This leads to a situation where, under some circumstances, a template invocation will work on one DNS Provider implementation, but not another.

I propose including clarifying language to the spec indicating that, while the retrieval of the template may be all lower case, the providerId and serviceId are still case sensitive. It is my hope that, with this clarifying language, it'll be clear to a DNS Provider implementor that case needs to be respected after the template is retrieved.