### PR TITLE
Typo in 4.2.2. Apply Template (Synchronous Flow)

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -557,7 +557,7 @@ OAuth flows the valid values for the error parameter will be as
 specified in OAuth 2.0 RFC 6749 (4.1.2.1. Error Response - "error"
 parameter). Valid values are: invalid_request, unauthorized_client,
 access_denied, unsupported_response_type, invalid_scope, server_error,
-and temporarilly_unavailable.
+and temporarily_unavailable.
 
 * Error Description
 +


### PR DESCRIPTION
Hello,

There is a small typo in the valid values for the `Error` parameter to be appended to the end of the `redirect_uri`.

> Valid values are: invalid_request, unauthorized_client, access_denied, unsupported_response_type, invalid_scope, server_error, and temporarilly_unavailable.

temporarily_unavailable should be written with one `l` and could cause issue if copy-pasted from the spec.