### PR TITLE
clarify 'Host/Name in Template' by adding ascii diagram

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -1952,6 +1952,50 @@ record of "xyz.bar" (or "xyz.bar.example.com." in bind format).
 A value of @ for host in the template is a placeholder for an empty value. In other words @
 would point to "bar.example.com." when the same template is applied to domain=example.com and host=bar.
 
+In summary.
+
+....
+       +------+
+       | user |
+       +------+
+          |
+          v
+   +----------------------------+
+   | https://.../apply?host=xyz |
+   +----------------------------+
+          |
+          v
+   +----------------------------------------+
+   | get domain from template: example.com. |
+   +----------------------------------------+
+          |
+          v
+   +------------------------------+
+   | does template include: host? |
+   +------------------------------+
+          |                    |
+         no                   yes
+          v                    |
+   +-------------------------+ |
+   | apply: xyz.example.com. | |
+   +-------------------------+ |
+            ^                  v
+            |   +----------------+
+           yes--| is the host: @ |
+                +----------------+
+                  | no
+                  v
+   +-----------------------------+
+   | get host from template: bar |
+   +-----------------------------+
+                  |
+                  v
+   +-----------------------------+
+   | apply: xyz.bar.example.com. |
+   +-----------------------------+
+
+....
+
 === PointsTo in Template
 
 Template records of certain types contain the pointsTo value to set in the zone. For


### PR DESCRIPTION
This update tries to make it really clear 'host' is a key word that exists in two namespaces 1) as a apply parameter, and 2) template value.  It would have been nice if these string had been different, but we have what we do and the best in this situation is to try to be as clear and explicit as possible the two 'hosts' are separate but related.

Co-authored-with: Jack Holdsworth <jholdsworth@cloudflare.com>