### PR TITLE
Fix inconsistencies

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -473,10 +473,8 @@ would be queried.
     "urlAPI": "https://api.domainconnect.virtucondomains.example",
     "width": 750,
     "height": 750,
-    "urlControlPanel": "https://domaincontrolpanel.virtucondomains.ex
-    ample/?domain=%domain%",
-    "nameServers": ["ns01.virtucondomainsdns.example", "ns02.virtucon
-    domainsdns.example"]
+    "urlControlPanel": "https://domaincontrolpanel.virtucondomains.example/?domain=%domain%",
+    "nameServers": ["ns01.virtucondomainsdns.example", "ns02.virtucondomainsdns.example"]
 }
 ----
 
@@ -823,7 +821,7 @@ p=3,a=RS256,d=weDjXrJwIDAQAB
 
 ----
 
-Here the public key is broken into four records in DNS, and the data
+Here the public key is broken into three records in DNS, and the data
 also indicates that the signing algorithm is an RSA Signature with
 SHA-256 using an x509 certificate. The value for "a" if omitted will be
 assumed to be RS256, and for "t" will be assumed to be x509.
@@ -1657,8 +1655,6 @@ Each record will contain the following elements.
 
 |*Type*
 |enum
-|type
-|(REQUIRED) Describes the type of record in DNS, or the operation impacting DNS. +
 |type
 |(REQUIRED) Describes the type of record in DNS, or the operation impacting DNS. +
 

--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -1910,8 +1910,8 @@ template when re-applying a template.
 To avoid unnecessary conflict warnings to the user, under normal use when re-applying a
 template such a DNS Provider should remove the previously applied template on the same host.
 
-This may not be desireable for all templates, as a limited set of templates are designed to
-be applied multiple times. To faciliate this the template can have the flag <<template-definition, multiInstance>>
+This may not be desirable for all templates, as a limited set of templates are designed to
+be applied multiple times. To facilitate this the template can have the flag <<template-definition, multiInstance>>
 set. This tells the DNS Provider that the template is expected to be written multiple times
 and that a re-apply MUST NOT remove previous instances.
 


### PR DESCRIPTION
* Remove duplicated line to fix Template Record table
Currently, the table containing the template record definition is broken because of a duplicate line:
![image](https://github.com/user-attachments/assets/60ce1ae6-e7bb-48ba-adcc-6dec7546b9d7)

* Correct the number of DNS records in which the public key is split
In the `Digitally Sign Requests` section, in the example about breaking down a public key into DNS records, the key is broken down into 3 DNS records but the text says it's broken into 4 records

* Fix formatting for urlControlPanel and nameServers
The example used in `DNS Provider Discovery` section has inconsistent formatting leading to a visually broken code snippet
![image](https://github.com/user-attachments/assets/858552eb-10f8-424e-b13a-b2c534967b13)

* Fix two typos in the multi-instance section