### PR TITLE
Updated License

### DIFF
--- a/Domain Connect Spec Draft.adoc
+++ b/Domain Connect Spec Draft.adoc
@@ -26,8 +26,6 @@ following license terms.
 
 The MIT License (MIT)
 
-Copyright (c) 2016 GoDaddy Operating Company, LLC.
-
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including
@@ -38,6 +36,9 @@ the following conditions:
 
 The above copyright notice and this permission notice shall be included
 in all copies or substantial portions of the Software.
+
+This software is dedicated to the public domain under the Creative Commons CC0 1.0 Universal Public Domain Dedication.
+To the extent possible under law, GoDaddy Operating Company, LLC, and Arnold Blinn have waived all copyright and related rights in this work.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
@@ -2591,3 +2592,4 @@ $ORIGIN example.com.
 er.
 example ~all"
 ----
+


### PR DESCRIPTION
Updated license to remove GoDaddy and Arnold Blinn copyrights.